### PR TITLE
feature: add multiple files and provide CLI completion for filenames

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,6 +9,7 @@ cache:
     - $CI_PROJECT_DIR/dist
 
 before_script:
+  - apk add git curl
   - sh -c "$(curl -fsSL https://raw.github.com/techdecaf/tasks/master/install.sh)"
 
 stages: [test, deploy]
@@ -17,7 +18,6 @@ test:
   image: golang:1.13-alpine
   stage: test
   script:
-    - apk add git
     - tasks run integration
     - go run . install https://github.com/techdecaf/cgen-template
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,6 +8,9 @@ cache:
   paths:
     - $CI_PROJECT_DIR/dist
 
+before_script:
+  - sh -c "$(curl -fsSL https://raw.github.com/techdecaf/tasks/master/install.sh)"
+
 stages: [test, deploy]
 
 test:

--- a/cmd/promote.go
+++ b/cmd/promote.go
@@ -9,57 +9,52 @@ import (
 	"github.com/techdecaf/utils"
 )
 
-// promoteCmd represents the promote command
-var promoteCmd = &cobra.Command{
-	Use:   "promote",
-	Short: "promote a file from a project to your cgen template",
-	Long: `this command takes a file that you have modified in your current project
-  and uses it to overrite the coresponding file in your cgen template.
-  `,
-	Run: func(cmd *cobra.Command, args []string) {
-		// parse flags
-		var src, file, commit string
-		var push, asTemplate bool
-		var err error
+func doPromote(cmd *cobra.Command, args []string) {
+	// parse flags
+	var file []string
+	var src, commit string
+	var push, asTemplate bool
+	var err error
 
-		if file, err = cmd.Flags().GetString("file"); err != nil {
-			app.Log.Fatal("cmd_flags", err)
-		}
+	if file, err = cmd.Flags().GetStringArray("files"); err != nil {
+		app.Log.Fatal("cmd_flags", err)
+	}
 
-		if commit, err = cmd.Flags().GetString("commit"); err != nil {
-			app.Log.Fatal("cmd_flags", err)
-		}
+	if commit, err = cmd.Flags().GetString("commit"); err != nil {
+		app.Log.Fatal("cmd_flags", err)
+	}
 
-		if asTemplate, err = cmd.Flags().GetBool("as-template"); err != nil {
-			app.Log.Fatal("cmd_flags", err)
-		}
+	if asTemplate, err = cmd.Flags().GetBool("as-template"); err != nil {
+		app.Log.Fatal("cmd_flags", err)
+	}
 
-		if push, err = cmd.Flags().GetBool("push"); err != nil {
-			app.Log.Fatal("cmd_flags", err)
-		}
+	if push, err = cmd.Flags().GetBool("push"); err != nil {
+		app.Log.Fatal("cmd_flags", err)
+	}
 
-		if src, err = cmd.Flags().GetString("path"); err != nil {
-			app.Log.Fatal("cmd_flags", err)
-		}
+	if src, err = cmd.Flags().GetString("path"); err != nil {
+		app.Log.Fatal("cmd_flags", err)
+	}
 
-		// initialize a new instance of cgen
-		if err := cgen.Init(); err != nil {
-			app.Log.Fatal("cgen_init", err)
-		}
+	// initialize a new instance of cgen
+	if err := cgen.Init(); err != nil {
+		app.Log.Fatal("cgen_init", err)
+	}
 
-		params := app.GeneratorParams{
-			TemplatesDir:   cgen.TemplatesDir, // directory of all cgen templates
-			Destination:    utils.PathTo(src), // destination directory for generated files
-			PerformUpgrade: false,             // run in upgrade mode
-			PromoteFile:    true,              // run file promotion mode
-			StaticOnly:     true,              // only copy static files, no template interpolation
-			Verbose:        true,              // use verbose logging
-		}
+	params := app.GeneratorParams{
+		TemplatesDir:   cgen.TemplatesDir, // directory of all cgen templates
+		Destination:    utils.PathTo(src), // destination directory for generated files
+		PerformUpgrade: false,             // run in upgrade mode
+		PromoteFile:    true,              // run file promotion mode
+		StaticOnly:     true,              // only copy static files, no template interpolation
+		Verbose:        true,              // use verbose logging
+	}
 
-		if err := cgen.Generator.Init(params); err != nil {
-			app.Log.Fatal("generator_init", err)
-		}
+	if err := cgen.Generator.Init(params); err != nil {
+		app.Log.Fatal("generator_init", err)
+	}
 
+	for _, file := range file {
 		var source = path.Join(cgen.Generator.Destination, file)
 		var template = path.Join(cgen.Generator.Source, "template", file)
 
@@ -70,16 +65,30 @@ var promoteCmd = &cobra.Command{
 		if err := cgen.Generator.Copy(source, template); err != nil {
 			app.Log.Fatal("cgen_promote", err)
 		}
+	}
 
-		if commit != "" {
-			fmt.Printf("the --commit flag has not yet been implemented, please consider a pull request (%v) \n", commit)
-		}
+	if commit != "" {
+		fmt.Printf("the --commit flag has not yet been implemented, please consider a pull request (%v) \n", commit)
+	}
 
-		if push {
-			fmt.Printf("the --push flag has not yet been implemented, please consider a pull request (%v) \n", push)
-		}
+	if push {
+		fmt.Printf("the --push flag has not yet been implemented, please consider a pull request (%v) \n", push)
+	}
 
-	},
+}
+
+// annotations := []string{}
+// annotation := make(map[string][]string)
+// annotation[cobra.BashCompFilenameExt] = annotations
+
+// promoteCmd represents the promote command
+var promoteCmd = &cobra.Command{
+	Use:   "promote",
+	Short: "promote a file from a project to your cgen template",
+	Long: `this command takes a file that you have modified in your current project
+  and uses it to overrite the coresponding file in your cgen template.
+  `,
+	Run: doPromote,
 }
 
 func init() {
@@ -94,7 +103,8 @@ func init() {
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
 	// promoteCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
-	promoteCmd.Flags().StringP("file", "f", "", "relative file path to the file you wish to promote.")
+	promoteCmd.Flags().StringArrayP("files", "f", []string{}, "relative file path to the files you wish to promote.")
+	promoteCmd.MarkFlagFilename("files", "*")
 	promoteCmd.Flags().StringP("commit", "c", "", "commit the promoted file to your cgen template.")
 	promoteCmd.Flags().StringP("path", "p", pwd, "the root directory containing a .cgen.yaml file")
 


### PR DESCRIPTION
@DecafCEO This took longer then it should have, but I did get cgen to autocomplete the filenames and multiple files in one CLI. Here would be an example:
`cgen promote -f file1.yml -f file2.json`